### PR TITLE
🐛 Backport kubeadm controlplane paths fix

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -436,7 +436,11 @@ func paths(path []string, diff map[string]interface{}) [][]string {
 	for key, m := range diff {
 		nested, ok := m.(map[string]interface{})
 		if !ok {
-			allPaths = append(allPaths, append(path, key))
+			// We have to use a copy of path, because otherwise the slice we append to
+			// allPaths would be overwritten in another iteration.
+			tmp := make([]string, len(path))
+			copy(tmp, path)
+			allPaths = append(allPaths, append(tmp, key))
 			continue
 		}
 		allPaths = append(allPaths, paths(append(path, key), nested)...)

--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook_test.go
@@ -1081,6 +1081,23 @@ func TestPaths(t *testing.T) {
 			diff:     map[string]interface{}{},
 			expected: [][]string{},
 		},
+		{
+			name: "long recursive check with two keys",
+			diff: map[string]interface{}{
+				"spec": map[string]interface{}{
+					"kubeadmConfigSpec": map[string]interface{}{
+						"clusterConfiguration": map[string]interface{}{
+							"version": "v2.0.1",
+							"abc":     "d",
+						},
+					},
+				},
+			},
+			expected: [][]string{
+				{"spec", "kubeadmConfigSpec", "clusterConfiguration", "version"},
+				{"spec", "kubeadmConfigSpec", "clusterConfiguration", "abc"},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Backport of https://github.com/kubernetes-sigs/cluster-api/pull/5670
It was [merged](https://github.com/kubernetes-sigs/cluster-api/pull/5765) in the release-1.0 branch but didn't make it in time for 1.0.2, so cherry-picking manually until 1.0.3 is released
This was breaking upgrades for clusters with stacked etcd