### PR TITLE
Add status.version to list of fields to ignore for update

### DIFF
--- a/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
+++ b/controlplane/kubeadm/api/v1beta1/kubeadm_control_plane_webhook.go
@@ -99,6 +99,7 @@ func (in *KubeadmControlPlane) ValidateCreate() error {
 
 const (
 	spec                 = "spec"
+	status               = "status"
 	kubeadmConfigSpec    = "kubeadmConfigSpec"
 	clusterConfiguration = "clusterConfiguration"
 	initConfiguration    = "initConfiguration"
@@ -150,6 +151,7 @@ func (in *KubeadmControlPlane) ValidateUpdate(old runtime.Object) error {
 		{spec, "rolloutAfter"},
 		{spec, "nodeDrainTimeout"},
 		{spec, "rolloutStrategy", "*"},
+		{status, "version"},
 	}
 
 	allErrs := validateKubeadmControlPlaneSpec(in.Spec, in.Namespace, field.NewPath("spec"))


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

When `KubeadmControlPlane` was upgraded to v1beta1, the `status.version` field was added which was called out here: https://github.com/kubernetes-sigs/cluster-api/blob/main/controlplane/kubeadm/api/v1alpha3/conversion.go#L98

Because of this, with the `Update` function we are taking advantage of in our controller, the validation webhook for `KubeadmControlPlane` is failing saying that changes to this field is forbidden. By adding it to the list of paths to ignore, we can get past this error which is specific to this field. 

When making the commit to upstream, either we go with this approach or edit the conversion logic somehow to be able to understand how to get the value of the version from the spec potentially when converting from v1alpha3 to v1beta1. For now though, we can go with this approach and figure out what upstream maintainers prefer as the approach.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
