### PR TITLE
✨ Bottle rocket taints support for worker nodes

### DIFF
--- a/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
+++ b/bootstrap/kubeadm/controllers/kubeadmconfig_controller.go
@@ -601,6 +601,9 @@ func (r *KubeadmConfigReconciler) joinWorker(ctx context.Context, scope *Scope) 
 		if scope.Config.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs != nil {
 			bottlerocketConfig.KubeletExtraArgs = scope.Config.Spec.JoinConfiguration.NodeRegistration.KubeletExtraArgs
 		}
+		if len(scope.Config.Spec.JoinConfiguration.NodeRegistration.Taints) > 0 {
+			bottlerocketConfig.Taints = scope.Config.Spec.JoinConfiguration.NodeRegistration.Taints
+		}
 		cloudJoinData, err = bottlerocket.NewNode(cloudJoinInput, bottlerocketConfig)
 		if err != nil {
 			scope.Error(err, "Failed to create a worker bottlerocket join configuration")

--- a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
@@ -16,6 +16,12 @@ standalone-mode = true
 authentication-mode = "tls"
 server-tls-bootstrap = false
 pod-infra-container-image = "{{.PauseContainerSource}}"
+[settings.kubernetes.node-taints]
+{{- if .Taints }}
+{{ range .Taints}}
+- {{ .Key }} = {{ .Value }}:{{ .Effect }}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 `
 	bootstrapHostContainerTemplate = `{{define "bootstrapHostContainerSettings" -}}

--- a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
@@ -20,10 +20,7 @@ pod-infra-container-image = "{{.PauseContainerSource}}"
 `
 	taintsTemplate = `{{ define "taintsTemplate" - }}
 [settings.kubernetes.node-taints]
-{{- if .Taints }}
-{{ range .Taints}}
-- {{ .Key }} = {{ .Value }}:{{ .Effect }}
-{{- end -}}
+{{.Taints}}
 {{- end -}}
 `
 

--- a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
@@ -16,14 +16,17 @@ standalone-mode = true
 authentication-mode = "tls"
 server-tls-bootstrap = false
 pod-infra-container-image = "{{.PauseContainerSource}}"
+{{- end -}}
+`
+	taintsTemplate = `{{ define "taintsTemplate" - }}
 [settings.kubernetes.node-taints]
 {{- if .Taints }}
 {{ range .Taints}}
 - {{ .Key }} = {{ .Value }}:{{ .Effect }}
 {{- end -}}
 {{- end -}}
-{{- end -}}
 `
+
 	bootstrapHostContainerTemplate = `{{define "bootstrapHostContainerSettings" -}}
 [settings.host-containers.kubeadm-bootstrap]
 enabled = true
@@ -74,6 +77,10 @@ trusted=true
 
 {{- if (ne .NodeLabels "")}}
 {{template "nodeLabelSettings" .}}
+{{- end -}}
+
+{{- if (ne .Taints "")}}
+{{template "taintsTemplate" .}}
 {{- end -}}
 `
 )

--- a/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bootstrap.go
@@ -18,11 +18,6 @@ server-tls-bootstrap = false
 pod-infra-container-image = "{{.PauseContainerSource}}"
 {{- end -}}
 `
-	taintsTemplate = `{{ define "taintsTemplate" - }}
-[settings.kubernetes.node-taints]
-{{.Taints}}
-{{- end -}}
-`
 
 	bootstrapHostContainerTemplate = `{{define "bootstrapHostContainerSettings" -}}
 [settings.host-containers.kubeadm-bootstrap]
@@ -54,6 +49,12 @@ trusted=true
 {{.NodeLabels}}
 {{- end -}}
 `
+	taintsTemplate = `{{ define "taintsTemplate" -}}
+[settings.kubernetes.node-taints]
+{{.Taints}}
+{{- end -}}
+`
+
 	bottlerocketNodeInitSettingsTemplate = `{{template "bootstrapHostContainerSettings" .}}
 
 {{template "adminContainerInitSettings" .}}

--- a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
@@ -142,7 +142,7 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
 		HTTPSProxyEndpoint:         config.ProxyConfiguration.HTTPSProxy,
 		RegistryMirrorEndpoint:     config.RegistryMirrorConfiguration.Endpoint,
 		NodeLabels:                 parseNodeLabels(config.KubeletExtraArgs["node-labels"]), // empty string if it does not exist
-		Taints:                     ,
+		Taints:                     parseTaints(config.Taints), //empty string if it does not exist
 	}
 	if len(config.ProxyConfiguration.NoProxy) > 0 {
 		for _, noProxy := range config.ProxyConfiguration.NoProxy {
@@ -167,6 +167,7 @@ func parseTaints(taints []corev1.Taint) string {
 	var taintsToml strings.Builder
 	for _, taint := range taints {
 		taintsToml.WriteString(fmt.Sprintf("\"%v\" = [\"%v\":\"%v\"]", taint.Key, taint.Value, taint.Effect))
+		taintsToml.WriteString("\n")
 	}
 	return taintsToml.String()
 }

--- a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
@@ -107,6 +107,9 @@ func generateNodeUserData(kind string, tpl string, data interface{}) ([]byte, er
 	if _, err := tm.Parse(nodeLabelsTemplate); err != nil {
 		return nil, errors.Wrapf(err, "failed to parse node labels %s template", kind)
 	}
+	if _, err := tm.Parse(taintsTemplate); err != nil {
+		return nil, errors.Wrapf(err, "failed to parse taints %s template", kind)
+	}
 	t, err := tm.Parse(tpl)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse %s template", kind)
@@ -166,7 +169,7 @@ func parseTaints(taints []corev1.Taint) string {
 	}
 	var taintsToml strings.Builder
 	for _, taint := range taints {
-		taintsToml.WriteString(fmt.Sprintf("\"%v\" = [\"%v\":\"%v\"]", taint.Key, taint.Value, taint.Effect))
+		taintsToml.WriteString(fmt.Sprintf("\"%v\" = [\"%v:%v\"]", taint.Key, taint.Value, taint.Effect))
 		taintsToml.WriteString("\n")
 	}
 	return taintsToml.String()

--- a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"text/template"
 
+	corev1 "k8s.io/api/core/v1"
 	bootstrapv1 "sigs.k8s.io/cluster-api/bootstrap/kubeadm/api/v1beta1"
 
 	"github.com/pkg/errors"
@@ -27,6 +28,7 @@ type BottlerocketConfig struct {
 	ProxyConfiguration          bootstrapv1.ProxyConfiguration
 	RegistryMirrorConfiguration bootstrapv1.RegistryMirrorConfiguration
 	KubeletExtraArgs            map[string]string
+	Taints			            []corev1.Taint
 }
 
 type BottlerocketSettingsInput struct {

--- a/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
+++ b/bootstrap/kubeadm/internal/bottlerocket/bottlerocket.go
@@ -41,6 +41,7 @@ type BottlerocketSettingsInput struct {
 	RegistryMirrorEndpoint     string
 	RegistryMirrorCACert       string
 	NodeLabels                 string
+	Taints                     string
 }
 
 type HostPath struct {
@@ -141,6 +142,7 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
 		HTTPSProxyEndpoint:         config.ProxyConfiguration.HTTPSProxy,
 		RegistryMirrorEndpoint:     config.RegistryMirrorConfiguration.Endpoint,
 		NodeLabels:                 parseNodeLabels(config.KubeletExtraArgs["node-labels"]), // empty string if it does not exist
+		Taints:                     ,
 	}
 	if len(config.ProxyConfiguration.NoProxy) > 0 {
 		for _, noProxy := range config.ProxyConfiguration.NoProxy {
@@ -156,6 +158,17 @@ func getBottlerocketNodeUserData(bootstrapContainerUserData []byte, users []boot
 		return nil, err
 	}
 	return bottlerocketNodeUserData, nil
+}
+
+func parseTaints(taints []corev1.Taint) string {
+	if len(taints) == 0 {
+		return ""
+	}
+	var taintsToml strings.Builder
+	for _, taint := range taints {
+		taintsToml.WriteString(fmt.Sprintf("\"%v\" = [\"%v\":\"%v\"]", taint.Key, taint.Value, taint.Effect))
+	}
+	return taintsToml.String()
 }
 
 func parseNodeLabels(nodeLabels string) string {


### PR DESCRIPTION
**What this PR does / why we need it**:
taints support for BottleRocket OS.

When a `taint` is specified in the configuration, parse it into `toml` of the format: 
```toml
"key" = ["value:Effect"]
"key" = ["value:Effect", "value2:Effect"]
```
and populate the bootstrap configuration userdata for the BR node with these parsed taint values.

To test this, I:
- stood up a local kind cluster
- ran the modified cluster-api and vsphere provider on the kind cluster via `tilt up`
- applied a BottleRocket cluster CAPI spec to the local mgmt cluster (generated from an EKS-A spec earlier)
- observed that the worker nodes come up and are tainted as expected (multiple taints per worker, some sharing a key)

