### PR TITLE
Change format for storing etcd machine address

### DIFF
--- a/controllers/machine_controller_phases.go
+++ b/controllers/machine_controller_phases.go
@@ -352,7 +352,6 @@ func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, cluster
 					if machineIP == "" {
 						return ctrl.Result{}, fmt.Errorf("error getting etcd init IP address: %v", err)
 					}
-
 					secret := &corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      etcdSecretName,
@@ -371,6 +370,7 @@ func (r *MachineReconciler) reconcileInfrastructure(ctx context.Context, cluster
 						},
 						Data: map[string][]byte{
 							"address": []byte(machineIP),
+							"clientUrls": []byte(fmt.Sprintf("https://%v:2379", machineIP)),
 						},
 						Type: clusterv1.ClusterSecretType,
 					}


### PR DESCRIPTION
Once the first etcd member is initialized, the machine controller has
to update the secret with the address of the machine, so it can be used
by other members to join during cluster creation.
The etcdadm-bootstrap-provider changes this address into an etcd client URL
before passing it in to the join command.
Recent changes in etcdadm, and etcdadm-controller will allow passing in
client URLs of all etcd members. So this commit changes the format of stored
address for the first machine from an IP address to the etcd client URL.
NOTE: This only happens once initially during cluster creation. We need to
keep this Secret because after clusterctl move, the etcdCluster's Initialized
condition needs to be set based on the existence of this Secret.

<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
